### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unofficial [Dropbox Paper](https://paper.dropbox.com) desktop application.
 ## Installation
 ### Homebrew [Cask](http://caskroom.io/)
 ```
-$ brew update && brew cask install morkro-papyrus
+$ brew update && brew install --cask morkro-papyrus
 ```
 
 ### Manually


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524